### PR TITLE
Improve Docker setup with multi-stage builds and caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ The original code is from the course, with some modifications:
 
 See the makefile for the available commands.
 
+## Environment Variables
+
+The following environment variables are used in the Dockerfile to configure the application:
+
+- `READ_TIMEOUT`: The maximum duration for reading the entire request, including the body. Default is `5s`.
+- `WRITE_TIMEOUT`: The maximum duration before timing out writes of the response. Default is `10s`.
+- `IDLE_TIMEOUT`: The maximum amount of time to wait for the next request when keep-alives are enabled. Default is `120s`.
+- `SHUTDOWN_TIMEOUT`: The maximum amount of time to wait for the server to shut down gracefully. Default is `5s`.
+- `OTEL_EXPORTER_OTLP_ENDPOINT`: The endpoint for the OpenTelemetry collector. This is a required variable.
+- `API_HOST`: The host and port for the API server. Default is `0.0.0.0:3000`.
+- `DEBUG_HOST`: The host and port for the debug server. Default is `0.0.0.0:3010`.
+
 ## Acknowledgments
 
 * [ardanlabs](https://github.com/ardanlabs/)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ The course is available at [https://www.ardanlabs.com/](https://www.ardanlabs.co
 Currently includes a single service set up to run in a Kubernetes cluster using Kind.
 The original code is from the course, with some modifications: 
  - Podman is used instead of Docker
- - OTEL is used for tracing
- - Dependencies are simplified in favor of the standard library
+ - OTEL is used for tracing and visualized with Jaeger
+ - Simplified abstractions where direct approaches felt more appropriate
 
 ## Getting Started
 
@@ -26,7 +26,7 @@ See the makefile for the available commands.
 
 ## Environment Variables
 
-The following environment variables are used in the Dockerfile to configure the application:
+The following environment variables are used to configure the application:
 
 - `READ_TIMEOUT`: The maximum duration for reading the entire request, including the body. Default is `5s`.
 - `WRITE_TIMEOUT`: The maximum duration before timing out writes of the response. Default is `10s`.

--- a/docker/dockerfile
+++ b/docker/dockerfile
@@ -2,11 +2,12 @@ FROM golang:1.24 AS dependencies
 WORKDIR /src
 
 COPY go.mod .
+COPY go.sum .
 ENV GOOS=linux
 ENV GOARCH=amd64
 
-RUN apt-get update && apt-get install -y --no-install-recommends
-RUN go mod download
+RUN --mount=type=cache,target=/go/pkg/mod \
+    go mod download
 
 FROM dependencies AS builder
 ARG BUILD_REF


### PR DESCRIPTION
Update Dockerfile to improve caching and add environment variable documentation in README.md.

* **Dockerfile Changes:**
  - Add a separate stage to cache Go modules using `--mount=type=cache` option.
  - Include `go.sum` file for module dependency resolution.

* **README.md Changes:**
  - Add a section to document the environment variables used in the Dockerfile, including `READ_TIMEOUT`, `WRITE_TIMEOUT`, `IDLE_TIMEOUT`, `SHUTDOWN_TIMEOUT`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `API_HOST`, and `DEBUG_HOST`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/wildenthal/ardanlabs-service/pull/1?shareId=019e967c-79ca-4a22-90ac-ba6cd675449d).